### PR TITLE
Fix slim-select mobile modal and pin version

### DIFF
--- a/html/views/database.view.php
+++ b/html/views/database.view.php
@@ -30,8 +30,8 @@
     </form>
   </div>
 </div>
-<script src="https://unpkg.com/slim-select@latest/dist/slimselect.js" crossorigin="anonymous"></script>
-<link href="https://unpkg.com/slim-select@latest/dist/slimselect.css" rel="stylesheet" crossorigin="anonymous">
+<script src="https://unpkg.com/slim-select@4.0.0/dist/slimselect.js" crossorigin="anonymous"></script>
+<link href="https://unpkg.com/slim-select@4.0.0/dist/slimselect.css" rel="stylesheet" crossorigin="anonymous">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" crossorigin="anonymous">
 <script src="https://cdn.jsdelivr.net/npm/flatpickr" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/plugins/rangePlugin.js" crossorigin="anonymous"></script>

--- a/html/views/transaction/record.view.php
+++ b/html/views/transaction/record.view.php
@@ -129,8 +129,8 @@
     <div id="ss-dropdown"></div>
   </form>
 </div>
-<script src="https://unpkg.com/slim-select@latest/dist/slimselect.js" crossorigin="anonymous"></script>
-<link href="https://unpkg.com/slim-select@latest/dist/slimselect.css" rel="stylesheet" crossorigin="anonymous">
+<script src="https://unpkg.com/slim-select@4.0.0/dist/slimselect.js" crossorigin="anonymous"></script>
+<link href="https://unpkg.com/slim-select@4.0.0/dist/slimselect.css" rel="stylesheet" crossorigin="anonymous">
 </link>
 <script>
   const FORM = document.querySelector('form#form');
@@ -165,6 +165,7 @@
     FORM.jenis_transaksi.SlimSelect = new SlimSelect({
       select: FORM.jenis_transaksi,
       settings: {
+        modal: 'off',
         contentLocation: document.querySelector('#ss-dropdown'),
         allowDeselect: false
       }
@@ -173,7 +174,7 @@
       select: FORM.rekening_sumber,
       data: ARGS.Rekening.map(rekeningSelectFormater),
       settings: {
-
+        modal: 'off',
         contentLocation: document.querySelector('#ss-dropdown'),
         placeholderText: 'Rekening Sumber',
         allowDeselect: true
@@ -183,7 +184,7 @@
       select: FORM.rekening_masuk,
       data: ARGS.Rekening.map(rekeningSelectFormater),
       settings: {
-
+        modal: 'off',
         contentLocation: document.querySelector('#ss-dropdown'),
         placeholderText: 'Rekening Masuk',
         allowDeselect: true
@@ -196,7 +197,7 @@
     FORM.kelompok.SlimSelect = new SlimSelect({
       select: FORM.kelompok,
       settings: {
-
+        modal: 'off',
         contentLocation: document.querySelector('#ss-dropdown'),
         allowDeselect: true,
       },
@@ -208,7 +209,7 @@
     FORM.relasi_transaksi.SlimSelect = new SlimSelect({
       select: FORM.relasi_transaksi,
       settings: {
-
+        modal: 'off',
         contentLocation: document.querySelector('#ss-dropdown'),
         allowDeselect: true
       },


### PR DESCRIPTION
Pin slim-select version to 4.0.0 and disable mobile modal to resolve broken behavior on mobile devices following the update.

---
*PR created automatically by Jules for task [4591846591356555472](https://jules.google.com/task/4591846591356555472) started by @khad1r*